### PR TITLE
Fix some spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ to your workflow.
 
 ## Under the hood
 
-This package downloads the relase information about Atom via the **GitHub API**
+This package downloads the release information about Atom via the **GitHub API**
 (this is what it makes it platform-independent, BTW).
 
 Based on your configuration settings the package may then notify you of newer
@@ -53,7 +53,7 @@ Short version: because I am a nerd.
 
 Longer version: because in nature atoms decay over time, transforming themselves
 into other elements and generating ionizing particles that can be picked up by a
-[geiger counter][1].  If an outated Atom version has "decayed", this package
+[geiger counter][1].  If an outdated Atom version has "decayed", this package
 should detect it! ;)
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Geiger
 **(previously known as 'atom-beta-notifier')**
 
-A platform-independend (Linux, Windows, etc...) package for being notified
+A platform-independent (Linux, Windows, etc...) package for being notified
 about newer-than-currently-in-use versions of Atom.
 
 ![Atom Beta Notifier: all is good](https://github.com/quasipedia/geiger/raw/master/screenshots/do-update.png)
@@ -21,7 +21,7 @@ to your workflow.
 ## Under the hood
 
 This package downloads the relase information about Atom via the **GitHub API**
-(this is what it makes it platform-independend, BTW).
+(this is what it makes it platform-independent, BTW).
 
 Based on your configuration settings the package may then notify you of newer
 stable or beta versions, or even just informing you are fully up-to-date.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "geiger",
   "main": "./lib/geiger",
   "version": "2.0.3",
-  "description": "A platform-independend notifier for new and beta versions of Atom",
+  "description": "A platform-independent notifier for new and beta versions of Atom",
   "keywords": [
     "beta",
     "new-versions",


### PR DESCRIPTION
I noticed the "platform-independend" typo in the description of the plugin when installing it and figured I'd to a pass on the spelling.  Hope you don't mind.
