### PR TITLE
Add buttons to open release pages when outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ should detect it! ;)
 
 ## Contributors
 
-Also contributed to the geiger: @skyrpex
+Also contributed to the geiger: @skyrpex @XanderXAJ
 
 
 ## To do

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Also contributed to the geiger: @skyrpex
 
 
 ## To do
-- Support links to platform-specific downloads (rpm, deb, exe...)
 - Improve notification look and functionality
 - Write tests
 

--- a/lib/geiger.js
+++ b/lib/geiger.js
@@ -12,39 +12,39 @@ const currentVersion = atom.getVersion()
 var timestampLastCheck
 
 const parseGithubApiLatestChannelVersions = (payload) => {
-  let channels = {};
+  let channels = {}
 
-  let stablePayload = payload.filter(release => !release.prerelease)[0];
+  let stablePayload = payload.filter(release => !release.prerelease)[0]
   channels.stable = {
     version:  stablePayload.tag_name,
     html_url: stablePayload.html_url
-  };
+  }
 
-  let betaPayload = payload.filter(release => release.prerelease)[0];
+  let betaPayload = payload.filter(release => release.prerelease)[0]
   channels.beta = {
     version:  betaPayload.tag_name,
     html_url: betaPayload.html_url
-  };
+  }
 
-  return channels;
+  return channels
 }
 
 const openUrl = (url) => {
-  shell.openExternal(url);
+  shell.openExternal(url)
 }
 
 const notify = (channels) => {
-  let latestVersion = channels.stable.version;
-  const considerBeta = atom.config.get('geiger.beta.include');
+  let latestVersion = channels.stable.version
+  const considerBeta = atom.config.get('geiger.beta.include')
   const msgLines = [
     `You are running version ${currentVersion}`,
     `Latest stable is ${channels.stable.version}`
-  ];
+  ]
 
   // Apply "include Beta" setting flag
   if (considerBeta) {
-    latestVersion = semver.gt(channels.beta.version, channels.stable.version) ? channels.beta.version : channels.stable.version;
-    msgLines.push(`Latest beta is ${channels.beta.version}`);
+    latestVersion = semver.gt(channels.beta.version, channels.stable.version) ? channels.beta.version : channels.stable.version
+    msgLines.push(`Latest beta is ${channels.beta.version}`)
   }
 
   // Up-to-date
@@ -66,21 +66,21 @@ const notify = (channels) => {
         {
           text: `View Stable Release`,
           onDidClick: () => {
-            openUrl(channels.stable.html_url);
-            notification.dismiss();
+            openUrl(channels.stable.html_url)
+            notification.dismiss()
           }
         }
-      ];
+      ]
       if (considerBeta) {
         buttons.push(
           {
             text: `View Beta Release`,
             onDidClick: () => {
-              openUrl(channels.beta.html_url);
-              notification.dismiss();
+              openUrl(channels.beta.html_url)
+              notification.dismiss()
             }
           }
-        );
+        )
       }
 
       let notification = atom.notifications.addWarning(
@@ -90,7 +90,7 @@ const notify = (channels) => {
           dismissable: atom.config.get('geiger.outdated.dismiss'),
           buttons: buttons
         }
-      );
+      )
     }
   }
   timestampLastCheck = Date.now()

--- a/lib/geiger.js
+++ b/lib/geiger.js
@@ -2,6 +2,7 @@
 
 import { CompositeDisposable } from 'atom'
 import semver from 'semver'
+import shell from 'shell'
 import { defaults } from './config'
 
 const apiReleasesURL = 'http://api.github.com/repos/atom/atom/releases'
@@ -10,25 +11,44 @@ const currentVersion = atom.getVersion()
 
 var timestampLastCheck
 
-const notify = (payload) => {
-  let latest
-  const latestStable = payload.filter(release => !release.prerelease)[0].tag_name
+const parseGithubApiLatestChannelVersions = (payload) => {
+  let channels = {};
+
+  let stablePayload = payload.filter(release => !release.prerelease)[0];
+  channels.stable = {
+    version:  stablePayload.tag_name,
+    html_url: stablePayload.html_url
+  };
+
+  let betaPayload = payload.filter(release => release.prerelease)[0];
+  channels.beta = {
+    version:  betaPayload.tag_name,
+    html_url: betaPayload.html_url
+  };
+
+  return channels;
+}
+
+const openUrl = (url) => {
+  shell.openExternal(url);
+}
+
+const notify = (channels) => {
+  let latestVersion = channels.stable.version;
+  const considerBeta = atom.config.get('geiger.beta.include');
   const msgLines = [
     `You are running version ${currentVersion}`,
-    `Latest stable is ${latestStable}`
-  ]
+    `Latest stable is ${channels.stable.version}`
+  ];
 
   // Apply "include Beta" setting flag
-  if (atom.config.get('geiger.beta.include')) {
-    const latestBeta = payload.filter(release => release.prerelease)[0].tag_name
-    msgLines.push(`Latest beta is ${latestBeta}`)
-    latest = semver.gt(latestBeta, latestStable) ? latestBeta : latestStable
-  } else {
-    latest = latestStable
+  if (considerBeta) {
+    latestVersion = semver.gt(channels.beta.version, channels.stable.version) ? channels.beta.version : channels.stable.version;
+    msgLines.push(`Latest beta is ${channels.beta.version}`);
   }
 
   // Up-to-date
-  if (semver.gte(currentVersion, latest)) {
+  if (semver.gte(currentVersion, latestVersion)) {
     if (atom.config.get('geiger.upToDate.notify')) {
       atom.notifications.addInfo(
         'Your version of Atom is <strong>UP-TO-DATE</strong>.',
@@ -42,13 +62,35 @@ const notify = (payload) => {
   // Outdated
   } else {
     if (atom.config.get('geiger.outdated.notify')) {
-      atom.notifications.addWarning(
+      let buttons = [
+        {
+          text: `View Stable Release`,
+          onDidClick: () => {
+            openUrl(channels.stable.html_url);
+            notification.dismiss();
+          }
+        }
+      ];
+      if (considerBeta) {
+        buttons.push(
+          {
+            text: `View Beta Release`,
+            onDidClick: () => {
+              openUrl(channels.beta.html_url);
+              notification.dismiss();
+            }
+          }
+        );
+      }
+
+      let notification = atom.notifications.addWarning(
         'Your version of Atom is <strong>OUTDATED</strong>.',
         {
           detail: msgLines.join('\n'),
-          dismissable: atom.config.get('geiger.outdated.dismiss')
+          dismissable: atom.config.get('geiger.outdated.dismiss'),
+          buttons: buttons
         }
-      )
+      );
     }
   }
   timestampLastCheck = Date.now()
@@ -95,7 +137,8 @@ export default {
   check() {
     fetch(apiReleasesURL)
       .then(response => response.json())
-      .then(json => notify(json))
+      .then(parseGithubApiLatestChannelVersions)
+      .then(notify)
       .catch(error => console.error('Error while fetching released from GitHub', error))
   }
 


### PR DESCRIPTION
Button opens the release's page on Github, e.g.:
https://github.com/atom/atom/releases/tag/v1.11.2

This then allows the user to download their file of choice.

![geiger-open-release-page](https://cloud.githubusercontent.com/assets/191109/19496204/6686bdcc-957e-11e6-9d9f-ee00cd4ef19d.png)

**Note:** I intended to also update the screenshot in the README, but my screen is such a small resolution that any screenshot I create will look jarring when compared to the other. ^^;
